### PR TITLE
Use `next/root-params` in `i18n/request.ts`

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,10 +1,7 @@
-import {locale as rootLocale} from 'next/root-params';
-import {notFound} from 'next/navigation';
-import {Locale, hasLocale, NextIntlClientProvider} from 'next-intl';
+import {NextIntlClientProvider} from 'next-intl';
 import {
-  getMessages,
+  getLocale,
   getTranslations,
-  setRequestLocale
 } from 'next-intl/server';
 import {clsx} from 'clsx';
 import {Inter} from 'next/font/google';
@@ -19,8 +16,7 @@ export function generateStaticParams() {
 }
 
 export async function generateMetadata() {
-  const locale = (await rootLocale()) as Locale;
-  const t = await getTranslations({locale, namespace: 'LocaleLayout'});
+  const t = await getTranslations('LocaleLayout');
 
   return {
     title: t('title')
@@ -32,18 +28,12 @@ export default async function LocaleLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const locale = await rootLocale();
-  if (!hasLocale(routing.locales, locale)) {
-    notFound();
-  }
-
-  setRequestLocale(locale);
-  const messages = await getMessages({locale});
+  const locale = await getLocale();
 
   return (
     <html className="h-full" lang={locale}>
       <body className={clsx(inter.className, 'flex h-full flex-col')}>
-        <NextIntlClientProvider locale={locale} messages={messages}>
+        <NextIntlClientProvider>
           <Navigation />
           {children}
         </NextIntlClientProvider>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,13 +1,9 @@
-import {locale as rootLocale} from 'next/root-params';
-import {Locale} from 'next-intl';
 import {Suspense} from 'react';
-import {getTranslations, setRequestLocale} from 'next-intl/server';
+import {getTranslations} from 'next-intl/server';
 import PageLayout from '@/components/PageLayout';
 import NavigationLink from '@/components/NavigationLink';
 
 export default async function IndexPage() {
-  setRequestLocale((await rootLocale()) as Locale);
-
   const t = await getTranslations('IndexPage');
 
   return (
@@ -38,9 +34,8 @@ async function DynamicComponent() {
 async function CachedComponent() {
   'use cache';
 
-  const locale = (await rootLocale()) as Locale;
   await new Promise((resolve) => setTimeout(resolve, 1000));
-  const t = await getTranslations({locale, namespace: 'IndexPage'});
+  const t = await getTranslations('IndexPage');
 
   return (
     <div className="mb-8 rounded-lg bg-gray-800 p-6">

--- a/src/app/[locale]/pathnames/page.tsx
+++ b/src/app/[locale]/pathnames/page.tsx
@@ -1,12 +1,7 @@
-import {locale as rootLocale} from 'next/root-params';
-import {Locale, useTranslations} from 'next-intl';
-import {setRequestLocale} from 'next-intl/server';
-import {use} from 'react';
+import {useTranslations} from 'next-intl';
 import PageLayout from '@/components/PageLayout';
 
 export default function PathnamesPage() {
-  setRequestLocale(use(rootLocale()) as Locale);
-
   const t = useTranslations('PathnamesPage');
 
   return (

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,12 +1,18 @@
+import * as rootParams from 'next/root-params';
 import {hasLocale} from 'next-intl';
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
+import { notFound } from 'next/navigation';
 
-export default getRequestConfig(async ({requestLocale}) => {
-  const requested = await requestLocale;
-  const locale = hasLocale(routing.locales, requested)
-    ? requested
-    : routing.defaultLocale;
+export default getRequestConfig(async ({locale}) => {
+  if (!locale) {
+    const paramValue = await rootParams.locale();
+    if (hasLocale(routing.locales, paramValue)) {
+      locale = paramValue;
+    } else {
+      notFound();
+    }
+  }
 
   return {
     locale,


### PR DESCRIPTION
This avoids reading `headers`, by reading from `next/root-params` in `i18n/request.ts`.

Once `next/root-params` is announced by the Next.js team, I'll be sure to publish my blog article at https://github.com/amannn/next-intl/pull/1632 (currently WIP) with a bit more background on the relevant changes here :)